### PR TITLE
change spdy executor to websocket executor

### DIFF
--- a/kube/ops.go
+++ b/kube/ops.go
@@ -127,7 +127,7 @@ func PodExecuteCommand(req ExecCommandRequest) (int, error) {
 		TTY:       false,
 	}, scheme.ParameterCodec)
 
-	exec, err := remotecommand.NewSPDYExecutor(req.RestConfig, "POST", execRequest.URL())
+	exec, err := remotecommand.NewWebSocketExecutor(req.RestConfig, "POST", execRequest.URL().String())
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
tested using kind v0.22.0 (node k8s v1.29.2) with server-side websocket feature gate enabled:
```yaml
kind: Cluster
apiVersion: kind.x-k8s.io/v1alpha4
featureGates:
  TranslateStreamCloseWebsocketRequests: true
```